### PR TITLE
[FIX] Wrong text in Add/Edit stock screen

### DIFF
--- a/lib/screens/add_edit_stock_screen.dart
+++ b/lib/screens/add_edit_stock_screen.dart
@@ -293,7 +293,7 @@ class _AddEditStockScreenState extends State<AddEditStockScreen> {
             children: [
               const Flexible(
                 child: Text(
-                  'Notify me when an ingredient falls below',
+                  'Notify me when stock is less than',
                   style: TextStyle(
                     fontSize: 16,
                     fontFamily: 'Inter',


### PR DESCRIPTION
<img width="305" alt="Screenshot 2567-10-31 at 13 39 15" src="https://github.com/user-attachments/assets/a0a8bf31-ef2a-4a05-a66a-e1823600ccff">


